### PR TITLE
fix for ghc-8.2.1

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -2,7 +2,7 @@ with import <nixpkgs> { };
 
 haskell.lib.buildStackProject {
   name = "stack2nix";
-  ghc = haskell.packages.ghc7103.ghc;
+  ghc = haskell.packages.ghc821.ghc;
   shellHook = "export SSL_CERT_FILE=${cacert}/etc/ssl/certs/ca-bundle.crt";
   buildInputs =
     [ z3

--- a/src/Data/HashMap/Mutable/Internal/UnsafeTricks.hs
+++ b/src/Data/HashMap/Mutable/Internal/UnsafeTricks.hs
@@ -21,6 +21,7 @@ import           Data.Vector.Mutable (MVector)
 import qualified Data.Vector.Mutable as M
 #ifdef UNSAFETRICKS
 import           GHC.Exts
+import           GHC.Types
 import           Unsafe.Coerce
 
 #if __GLASGOW_HASKELL__ >= 707

--- a/src/Data/Maybe/Unsafe.hs
+++ b/src/Data/Maybe/Unsafe.hs
@@ -10,6 +10,7 @@ import Unsafe.Coerce
 import System.IO.Unsafe
 import System.Mem.StableName
 import GHC.Prim
+import GHC.Types
 import Prelude hiding (maybe)
 
 thunk :: Int -> Int

--- a/src/Data/Primitive/Array/Maybe.hs
+++ b/src/Data/Primitive/Array/Maybe.hs
@@ -10,7 +10,8 @@ module Data.Primitive.Array.Maybe
 
 import Control.Monad.Primitive
 import Data.Primitive.Array
-import GHC.Prim (reallyUnsafePtrEquality#,Any)
+import GHC.Prim (reallyUnsafePtrEquality#)
+import GHC.Types (Any)
 import Unsafe.Coerce (unsafeCoerce)
 
 newtype MutableMaybeArray s a = MutableMaybeArray (MutableArray s Any)

--- a/src/Data/Primitive/MutVar/Maybe.hs
+++ b/src/Data/Primitive/MutVar/Maybe.hs
@@ -13,6 +13,7 @@ import Control.Monad.Primitive
 
 import Unsafe.Coerce
 import GHC.Prim
+import GHC.Types
 
 import Data.Maybe
 


### PR DESCRIPTION
As far as I can tell, the "Any" type family no longer resides in GHC.Prim as of GHC 8.2.1.

Builds for impure-containers succeed for ghc-8.0.2 : 
```bash
$ nix-shell -p "haskell.packages.ghc802.ghcWithPackages (pkgs: [pkgs.impure-containers])"
```

And fail for for ghc-8.2.1:
```bash
$ nix-shell -p "haskell.packages.ghc821.ghcWithPackages (pkgs: [pkgs.impure-containers])"
```

With this PR, builds succeed on both GHC 8.0.2 and GHC 8.2.1.