### PR TITLE
Improve ArrayList implementation

### DIFF
--- a/impure-containers.cabal
+++ b/impure-containers.cabal
@@ -88,10 +88,10 @@ library
                         , Data.HashMap.Mutable.Internal.UnsafeTricks
                         , Data.HashMap.Mutable.Internal.Utils
   build-depends:          base                        >= 4.8   && < 5
-                        , hashable                    >= 1.2   && < 1.3
-                        , primitive                   >= 0.6   && < 0.7
+                        , hashable                    >= 1.2   && < 1.4
+                        , primitive                   >= 0.6   && < 0.8
                         , vector                      >= 0.11  && < 0.13
-                        , containers                  >  0.5   && < 0.6
+                        , containers                  >  0.5   && < 0.7
                         , ghc-prim
   default-language:       Haskell2010
 

--- a/impure-containers.cabal
+++ b/impure-containers.cabal
@@ -1,7 +1,7 @@
 --------------------------------------------------------------------------------
 
 name:                     impure-containers
-version:                  0.5.0
+version:                  0.5.1
 stability:                Experimental
 build-type:               Simple
 cabal-version:            >= 1.10

--- a/src/Data/ArrayList/Generic.hs
+++ b/src/Data/ArrayList/Generic.hs
@@ -1,7 +1,37 @@
 {-# LANGUAGE BangPatterns #-}
 
-module Data.ArrayList.Generic where
+{- |
 
+Auto-growing 'ArrayList' type that over-allocates memory to optimize frequent resizes.
+
+This is similar to @std::vector@ from C++ or @list@ from Python.
+
+When an @ArrayList@ is requested to grow and current allocated capacity can't hold the
+required number of items, capacity is multiplied by a constant factor of @1.5@, instead
+of allocating just the required number of items. This ensures that frequent grow requests
+will result in a much lower number of actual allocations and memory moves.
+
+All functions in this module are marked @INLINEABLE@, so that they may be specialized to concrete
+monad and vector types at the use-site.
+-}
+module Data.ArrayList.Generic
+  (
+    -- * Creation of @ArrayList@s
+    ArrayList
+  , new, fromVector
+
+    -- * Accessing the underlying vector
+  , vector, size
+  , unsafeVector
+
+    -- * Extending the @ArrayList@
+  , push, grow
+
+    -- * Deconstruction of @ArrayList@s
+  , freeze
+  ) where
+
+import           Control.Monad               (when)
 import           Control.Monad.Primitive
 import           Data.Primitive.MutVar
 import           Data.Vector.Generic         (Mutable, Vector)
@@ -14,28 +44,99 @@ data ArrayList v s a = ArrayList
   , arrayListVector :: !(MutVar s (v s a))
   }
 
+-- | Create a new 'ArrayList' with requested capacity. The length of 'ArrayList' as reported by
+-- 'size' will be @0@.
 new :: (PrimMonad m, MVector v a) => Int -> m (ArrayList v (PrimState m) a)
 new len = ArrayList <$> newMutVar 0 <*> (newMutVar =<< GM.new len)
+{-# INLINEABLE new #-}
+
+-- | Create a new 'ArrayList' from immutable vector. Capacity will be equal to the length of vector.
+-- Memory will be copied, so that input vector is safe to use afterwards.
+fromVector :: (PrimMonad m, Vector v a) => v a -> m (ArrayList (Mutable v) (PrimState m) a)
+fromVector vec = ArrayList <$> newMutVar (GV.length vec) <*> (newMutVar =<< GV.thaw vec)
+{-# INLINEABLE fromVector #-}
+
+-- | Get underlying mutable vector that stores @ArrayList@'s data. Length of this vector will be set
+-- to the actually used length of @ArrayList@, not its capacity.
+vector :: (PrimMonad m, MVector v a) => ArrayList v (PrimState m) a -> m (v (PrimState m) a)
+vector (ArrayList sizeRef mvecRef) = do
+  !size_ <- readMutVar sizeRef
+  GM.unsafeTake size_ <$> readMutVar mvecRef
+{-# INLINEABLE vector #-}
+
+-- | Like 'vector', but do not set the length of resulting vector. Its length will be equal to the
+-- capacity of 'ArrayList'. This means that some elements of the vector will be uninitialized.
+unsafeVector :: (PrimMonad m, MVector v a) => ArrayList v (PrimState m) a -> m (v (PrimState m) a)
+unsafeVector (ArrayList _ mvecRef) = readMutVar mvecRef
+{-# INLINEABLE unsafeVector #-}
+
+-- | Get currently used size of the 'ArrayList'.
+size :: (PrimMonad m, MVector v a) => ArrayList v (PrimState m) a -> m Int
+size (ArrayList sizeRef _) = readMutVar sizeRef
+{-# INLINEABLE size #-}
 
 -- | Append an element to the end of the 'ArrayList'.
 push :: (PrimMonad m, MVector v a) => ArrayList v (PrimState m) a -> a -> m ()
-push (ArrayList sizeRef mvecRef) a = do
-  !size <- readMutVar sizeRef
-  !mvec <- readMutVar mvecRef
-  let !newSize = size + 1
-      vlen = GM.length mvec
-  writeMutVar sizeRef newSize
-  if size < vlen
-    then GM.unsafeWrite mvec size a
-    else do
-      newMVec <- GM.unsafeGrow mvec size
-      GM.unsafeWrite newMVec size a
-      writeMutVar mvecRef newMVec
+push al@(ArrayList sizeRef mvecRef) a = do
+  grow al 1
 
+  !size_ <- readMutVar sizeRef
+  !mvec <- readMutVar mvecRef
+
+  GM.unsafeWrite mvec (size_ - 1) a
+{-# INLINEABLE push #-}
+
+-- | Request to add more items to the vector. Used size will be set to current size + extra requested size.
+--
+-- __NOTE__: Do not use the result of 'vector' after calling this function, as it may refer to discarded
+-- memory.
+--
+-- This function defines two Cost Centres: "@ArrayList.grow.toNewSize@" when vector will grow to fit
+-- precisely the number of required elements, and "@ArrayList.grow.toNewCapacity@" when vector will
+-- over-allocate memory.
+--
+-- These may be useful when profiling your program to check how much allocations and moves 'ArrayList'
+-- does actually save.
+grow :: (PrimMonad m, MVector v a) => ArrayList v (PrimState m) a -> Int -> m ()
+grow (ArrayList sizeRef mvecRef) extraSize = do
+  !size_ <- readMutVar sizeRef
+  !mvec <- readMutVar mvecRef
+
+  let
+    capacity = GM.length mvec
+    newSize = size_ + extraSize
+    -- Next step in exponential grow
+    newCapacity = floor $ fromIntegral capacity * factor
+
+  -- Need to grow the vector only if the current capacity can't hold the requested size
+  when (capacity < newSize) $ do
+      -- Grow vector to be max (capacity * factor) (curSize + extraSize)
+      -- unsafeGrow will reallocate the vector and return newly created one.
+      --
+      -- NOTE: unsafeGrow accepts extra size requested, not total new size.
+      !mvec' <- if newSize > newCapacity
+         then
+           {-# SCC "ArrayList.grow.toNewSize" #-} GM.unsafeGrow mvec (newSize - capacity)
+         else
+           {-# SCC "ArrayList.grow.toNewCapacity" #-} GM.unsafeGrow mvec (newCapacity - capacity)
+
+      -- Ensure that the memory requested by user is initialized.
+      GM.basicInitialize $ GM.unsafeSlice size_ extraSize mvec'
+
+      writeMutVar mvecRef mvec'
+
+  -- In any case, remeber current used size.
+  writeMutVar sizeRef newSize
+{-# INLINEABLE grow #-}
+
+factor :: Double
+factor = 1.5
+
+-- | Make a copy of currently used part of 'ArrayList' and return it as an immutable vector.
 freeze :: (PrimMonad m, Vector v a) => ArrayList (Mutable v) (PrimState m) a -> m (v a)
 freeze (ArrayList sizeRef mvecRef) = do
-  !size <- readMutVar sizeRef
+  !size_ <- readMutVar sizeRef
   !mvec <- readMutVar mvecRef
-  let sizedMVec = GM.unsafeTake size mvec
+  let sizedMVec = GM.unsafeTake size_ mvec
   GV.freeze sizedMVec
-
+{-# INLINEABLE freeze #-}

--- a/src/Data/HashMap/Mutable/Internal/IntArray.hs
+++ b/src/Data/HashMap/Mutable/Internal/IntArray.hs
@@ -20,8 +20,10 @@ module Data.HashMap.Mutable.Internal.IntArray
 import           Control.Monad.Primitive  (PrimMonad, PrimState)
 import           Control.Monad.ST
 import           Data.Bits
-import qualified Data.Primitive.ByteArray as A
+#if !MIN_VERSION_primitive(0, 7, 0)
 import           Data.Primitive.Types     (Addr (..))
+#endif
+import qualified Data.Primitive.ByteArray as A
 import           GHC.Exts
 import           GHC.Word
 import           Prelude                  hiding (length)
@@ -113,4 +115,8 @@ length (IA a) = A.sizeofMutableByteArray a `div` wordSizeInBytes
 toPtr :: IntArray s -> Ptr a
 toPtr (IA a) = Ptr a#
   where
+#if MIN_VERSION_primitive(0,7,0)
+    !(Ptr !a#) = A.mutableByteArrayContents a
+#else
     !(Addr !a#) = A.mutableByteArrayContents a
+#endif

--- a/src/ImpureContainers/MByteArray.hs
+++ b/src/ImpureContainers/MByteArray.hs
@@ -1,5 +1,6 @@
 --------------------------------------------------------------------------------
 
+{-# LANGUAGE CPP       #-}
 {-# LANGUAGE MagicHash #-}
 
 --------------------------------------------------------------------------------
@@ -42,7 +43,11 @@ import           Data.Word               (Word8)
 
 import           Control.Monad.Primitive
 import           Data.Coerce             (coerce)
+#if MIN_VERSION_primitive(0, 7, 0)
+import           Data.Primitive          (Prim, Ptr)
+#else
 import           Data.Primitive          (Addr, Prim)
+#endif
 import qualified Data.Primitive
 
 import qualified GHC.Prim
@@ -108,7 +113,11 @@ newAlignedPinned = Data.Primitive.newAlignedPinnedByteArray
 contents
   :: MByteArray s
   -- ^ FIXME: doc
+#if MIN_VERSION_primitive(0, 7, 0)
+  -> Ptr Word8
+#else
   -> Addr
+#endif
   -- ^ FIXME: doc
 contents = Data.Primitive.mutableByteArrayContents
 {-# INLINE contents #-}

--- a/src/ImpureContainers/PrimRef.hs
+++ b/src/ImpureContainers/PrimRef.hs
@@ -31,6 +31,7 @@
 
 --------------------------------------------------------------------------------
 
+{-# LANGUAGE CPP             #-}
 {-# LANGUAGE MagicHash       #-}
 {-# LANGUAGE RoleAnnotations #-}
 {-# LANGUAGE UnboxedTuples   #-}
@@ -84,7 +85,12 @@ import           Data.Function               (($))
 import           Control.Monad.Primitive
                  (PrimMonad, PrimState, primitive, primitive_)
 
+#if MIN_VERSION_primitive(0, 7, 0)
+import           Data.Primitive              (Prim, Ptr, alignment, sizeOf)
+import           Data.Word                   (Word8)
+#else
 import           Data.Primitive              (Addr, Prim, alignment, sizeOf)
+#endif
 
 import qualified GHC.Prim                    as GHC.Prim
 import           GHC.Types                   (Int (I#))
@@ -180,7 +186,11 @@ instance Eq (PrimRef s a) where
 contents
   :: PrimRef s a
   -- ^ FIXME: doc
+#if MIN_VERSION_primitive(0, 7, 0)
+  -> Ptr Word8
+#else
   -> Addr
+#endif
   -- ^ FIXME: doc
 contents (MkPrimRef m) = MByteArray.contents m
 {-# INLINE contents #-}

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,27 +1,17 @@
+resolver: lts-14.25
+
+packages:
+- '.'
+
+extra-deps:
+- git: https://github.com/ucsd-progsys/liquidhaskell
+  commit: a41325c2aa5697a6bec9b6e8c39aabf0fddc3970
+- git: https://github.com/ucsd-progsys/liquid-fixpoint
+  commit: 752f9e5a572e175eda4c7c10d7a355456245c3ed
+- git: https://github.com/ucsd-progsys/prover
+  commit: f6a47df5a079f4b9586829203015cce6f82cebbb
+
 flags:
   vector:
     unsafechecks: true
     internalchecks: true
-extra-package-dbs: []
-packages:
-- '.'
-- location:
-    git: https://github.com/ucsd-progsys/liquidhaskell
-    commit: a41325c2aa5697a6bec9b6e8c39aabf0fddc3970
-  extra-dep: true
-- location:
-    git: https://github.com/ucsd-progsys/liquid-fixpoint
-    commit: 752f9e5a572e175eda4c7c10d7a355456245c3ed
-  extra-dep: true
-- location:
-    git: https://github.com/ucsd-progsys/prover
-    commit: f6a47df5a079f4b9586829203015cce6f82cebbb
-  extra-dep: true
-extra-deps:
-- daemons-0.2.1
-- dotgen-0.4.2
-- fgl-visualize-0.1.0.1
-- intern-0.9.1.4
-- located-base-0.1.1.0
-- vector-0.11.0.0
-resolver: lts-6.7


### PR DESCRIPTION
Current implementation of `ArrayList` has several problems:

- It grows the vector by factor of 2 when there is not enough space for elements, while it's nowadays common to use factors strictly less then two in vector implementations.
- It only supports `push` operation, not allowing to extend the vector by many elements at once.
- Most importantly, it doesn't expose the API to use the underlying mutable vector, instead users have to read `MutVar`s themselves.
- All functions are generic in monad and vector and lack inline pragmas.
- And it's not documented at all.

I've rewritten the implementation to fix all the points above, using growth factor of `1.5`.

Additionally, I achieved compatibility with newer `primitive` package, which will be included with LTS-15 with GHC-8.8.